### PR TITLE
Adding "--seed <seed>" parameter for seeding randomizer. Also prints seed.

### DIFF
--- a/src/PHPUnitRandomizer/Command.php
+++ b/src/PHPUnitRandomizer/Command.php
@@ -3,14 +3,66 @@ namespace PHPUnitRandomizer;
 
 class Command extends \PHPUnit_TextUI_Command
 {
+    /**
+     * Seed for the randomizer.
+     *
+     * Defaults to -1 until customized or when default value gets set.
+     *
+     * @var int
+     */
+    protected $seed = -1;
+
+    public function __construct()
+    {
+        $this->longOptions['seed='] = 'seed';
+    }
+
 	public static function main($exit = TRUE)
     {
         $command = new self;
         return $command->run($_SERVER['argv'], $exit);
     }
 
-	protected function createRunner()
-	{
-		return new TestRunner($this->arguments['loader']);
-	}
+    protected function seed($seed)
+    {
+        if (!is_numeric($seed)) {
+            echo("Invalid seed number, seed must be an integer." . PHP_EOL);
+            exit(\PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
+        }
+
+        $this->seed = intval($seed);
+    }
+
+    protected function handleArguments(array $argv)
+    {
+        parent::handleArguments($argv);
+
+        if ($this->seed === -1) {
+            // Default seed for randomizer, unless overridden.
+            // Used for printing the seed so it can be re-used.
+            $this->seed = rand(0, 9999);
+        }
+
+        if (!isset($this->arguments['printer'])) {
+            $printer = new ResultPrinter();
+            $printer->setSeed($this->seed);
+            $this->arguments['printer'] = $printer;
+        }
+    }
+
+    protected function createRunner()
+    {
+        return new TestRunner($this->arguments['loader'], null, $this->seed);
+    }
+
+    public function showHelp()
+    {
+        parent::showHelp();
+
+        print <<<EOT
+
+  --seed <seed>             Seed the randomizer with a specific seed.
+
+EOT;
+    }
 }

--- a/src/PHPUnitRandomizer/Decorator.php
+++ b/src/PHPUnitRandomizer/Decorator.php
@@ -3,8 +3,11 @@ namespace PHPUnitRandomizer;
 
 class Decorator extends \PHPUnit_Extensions_TestDecorator
 {
-    public function __construct(\PHPUnit_Framework_Test $test)
+    protected $seed = null;
+
+    public function __construct(\PHPUnit_Framework_Test $test, $seed = null)
     {
+        $this->seed = $seed;
         $tests = $this->randomizeTests( $test->tests() );
         $suite = $this->createTestSuite( $tests );
 
@@ -13,6 +16,8 @@ class Decorator extends \PHPUnit_Extensions_TestDecorator
 
     private function randomizeTests( array $tests )
     {
+        srand($this->seed);
+
         $shuffle = array();
         foreach ( $tests as $t )
         {

--- a/src/PHPUnitRandomizer/ResultPrinter.php
+++ b/src/PHPUnitRandomizer/ResultPrinter.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace PHPUnitRandomizer;
+
+class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter {
+
+    protected $seed = null;
+
+    public function setSeed($seed)
+    {
+        $this->seed = $seed;
+    }
+
+    protected function printFooter(\PHPUnit_Framework_TestResult $result)
+    {
+        parent::printFooter($result);
+
+        $this->writeNewLine();
+        $this->write("Randomized with seed {$this->seed}");
+        $this->writeNewLine();
+    }
+} 

--- a/src/PHPUnitRandomizer/TestRunner.php
+++ b/src/PHPUnitRandomizer/TestRunner.php
@@ -3,9 +3,15 @@ namespace PHPUnitRandomizer;
 
 class TestRunner extends \PHPUnit_TextUI_TestRunner
 {
+    public function __construct(PHPUnit_Runner_TestSuiteLoader $loader = NULL, PHP_CodeCoverage_Filter $filter = NULL, $seed = null)
+    {
+        parent::__construct($loader, $filter);
+        $this->seed = $seed;
+    }
+
 	public function doRun(\PHPUnit_Framework_Test $suite, array $arguments = array())
     {
-        $test 	= new Decorator( $suite );
+        $test 	= new Decorator($suite, $this->seed);
         $suite 	= new \PHPUnit_Framework_TestSuite();
         $suite->addTest($test);
 


### PR DESCRIPTION
Adds seed parameter for overriding the seed for the randomizer. 
This resolves issue https://github.com/fiunchinho/phpunit-randomizer/issues/1.

I've also added a custom ResultPrinter that outputs the seed from the run (custom or not), so a user can re-run with the same seed as previously randomized.

Would've loved to add some unit tests for this, but I decided to postpone that for now.
