### PR TITLE
Fix autload check: phpunit has the script at the root directory

### DIFF
--- a/bin/phpunit-randomizer
+++ b/bin/phpunit-randomizer
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-foreach (array(__DIR__ . '/../autoload.php', __DIR__ . '/../vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
This means the search path is wrong when copying it into bin/

This fixes the following annoying error when using phpunit-randomizer in
a project through composer:

You need to set up the project dependencies using the following commands:
wget http://getcomposer.org/composer.phar
php composer.phar install
