### PR TITLE
Find vendor autoloader when running from project root

### DIFF
--- a/bin/phpunit-randomizer
+++ b/bin/phpunit-randomizer
@@ -1,7 +1,7 @@
 #!/usr/bin/env php
 <?php
 
-foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php') as $file) {
+foreach (array(__DIR__ . '/../../../autoload.php', __DIR__ . '/../vendor/autoload.php', __DIR__ . '/vendor/autoload.php') as $file) {
     if (file_exists($file)) {
         define('PHPUNIT_COMPOSER_INSTALL', $file);
         break;


### PR DESCRIPTION
Allowing execution of the test suite from the project root. Same config enabled in phpunit/phpunit package.
