### PR TITLE
Moved dependency to PHPUnit version to development dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,8 @@
         }
     ],
     "require": {
+    },
+    "require-dev": {
         "phpunit/phpunit": "4.2.*"
     },
     "bin": ["bin/phpunit-randomizer"],


### PR DESCRIPTION
Requiring a specific version as runtime dependency makes conflicts with
other PHPUnit libraries (i.e. EcomDev_PHPUnit) very likely
