### PR TITLE
Fix TestRunner.php for PHP7

### DIFF
--- a/src/PHPUnitRandomizer/TestRunner.php
+++ b/src/PHPUnitRandomizer/TestRunner.php
@@ -10,7 +10,7 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
      * @param  PHPUnit_Framework_Test $suite     TestSuite to execute
      * @param  array                  $arguments Arguments to use
      */
-    public function doRun(\PHPUnit_Framework_Test $suite, array $arguments = array())
+    public function doRun(\PHPUnit_Framework_Test $suite, array $arguments = array(), $exit = true)
     {
         $localArguments = $arguments;
 


### PR DESCRIPTION
Executing PHPUnitRandomizer on PHP7 we've found this error, so we're sending you this pull request to fix this.

```
PHP Fatal error: Uncaught Declaration of PHPUnitRandomizer\TestRunner::doRun(PHPUnit_Framework_Test $suite, array $arguments = Array) should be compatible with PHPUnit_TextUI_TestRunner::doRun(PHPUnit_Framework_Test $suite, array $arguments = Array, $exit = true)
```