### PR TITLE
Updated PHPUnit classes to be compatible with namespaces of PHPUnit 6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.2 || ^5.0"
+        "phpunit/phpunit": "^6.0"
     },
     "bin": ["bin/phpunit-randomizer"],
     "autoload": {

--- a/example_tests/ExampleTest.php
+++ b/example_tests/ExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class ExampleTest extends \PHPUnit_Framework_TestCase
+class ExampleTest extends \PHPUnit\Framework\TestCase
 {
 	public static $setUpBeforeClass = -1;
 	public $setUp;

--- a/example_tests/OtherExampleTest.php
+++ b/example_tests/OtherExampleTest.php
@@ -1,6 +1,6 @@
 <?php
 
-class OtherExampleTest extends \PHPUnit_Framework_TestCase
+class OtherExampleTest extends \PHPUnit\Framework\TestCase
 {
 	public static $setUpBeforeClass = -1;
 	public $setUp;

--- a/src/PHPUnitRandomizer/Command.php
+++ b/src/PHPUnitRandomizer/Command.php
@@ -1,7 +1,7 @@
 <?php
 namespace PHPUnitRandomizer;
 
-class Command extends \PHPUnit_TextUI_Command
+class Command extends \PHPUnit\TextUI\Command
 {
     public function __construct()
     {
@@ -15,7 +15,7 @@ class Command extends \PHPUnit_TextUI_Command
 
     /**
      * Only called when 'order' argument is used.
-     * 
+     *
      * @param  string $order_parameter The order argument passed in command line.
      */
     protected function orderHandler($order_parameter)
@@ -27,7 +27,7 @@ class Command extends \PHPUnit_TextUI_Command
 
     /**
      * Parses arguments to know if random order is desired, and if seed was chosen.
-     * 
+     *
      * @param  string $order String from command line parameter.
      * @return array
      */
@@ -69,8 +69,8 @@ EOT;
 
     private function showError($message)
     {
-        print \PHPUnit_Runner_Version::getVersionString() . "\n\n";
+        print \PHPUnit\Runner\Version::getVersionString() . "\n\n";
         print $message . "\n";
-        exit(\PHPUnit_TextUI_TestRunner::FAILURE_EXIT);
+        exit(\PHPUnit\TextUI\TestRunner::FAILURE_EXIT);
     }
 }

--- a/src/PHPUnitRandomizer/Randomizer.php
+++ b/src/PHPUnitRandomizer/Randomizer.php
@@ -7,11 +7,11 @@ class Randomizer
     /**
      * Order the TestSuite tests in a random order.
      *
-     * @param  \PHPUnit_Framework_Test $suite The suite to randomize.
+     * @param  \PHPUnit\Framework\Test $suite The suite to randomize.
      * @param  integer                 $seed  Seed used for PHP to randomize the suite.
-     * @return \PHPUnit_Framework_Test
+     * @return \PHPUnit\Framework\Test
      */
-    public function randomizeTestSuite(\PHPUnit_Framework_Test $suite, $seed)
+    public function randomizeTestSuite(\PHPUnit\Framework\Test $suite, $seed)
     {
         if ($this->testSuiteContainsOtherSuites($suite))
         {
@@ -30,7 +30,7 @@ class Randomizer
      *
      * @param  [type] $suite Main Test Suite to randomize.
      * @param  [type] $seed  Seed to use.
-     * @return \PHPUnit_Framework_Test
+     * @return \PHPUnit\Framework\Test
      */
     private function randomizeSuiteThatContainsOtherSuites($suite, $seed)
     {
@@ -45,23 +45,23 @@ class Randomizer
     /**
      * Test Suites can contain other Test Suites or just Test Cases.
      *
-     * @param  \PHPUnit_Framework_Test $suite [description]
+     * @param  \PHPUnit\Framework\Test $suite [description]
      * @return Boolean
      */
     private function testSuiteContainsOtherSuites($suite)
     {
         $tests = $suite->tests();
-        return isset($tests[0]) && $tests[0] instanceof \PHPUnit_Framework_TestSuite;
+        return isset($tests[0]) && $tests[0] instanceof \PHPUnit\Framework\TestSuite;
     }
 
     /**
      * Randomize the test cases inside a TestSuite, with the given seed.
      *
-     * @param  \PHPUnit_Framework_Test     $suite Test suite to randomize.
+     * @param  \PHPUnit\Framework\Test     $suite Test suite to randomize.
      * @param  integer                     $seed  Seed to be used for the random funtion.
      * @param  integer                     $order Arbitrary value to "salt" the seed.
      * @param  bool                        $fix_depends [=false]
-     * @return \PHPUnit_Framework_Test
+     * @return \PHPUnit\Framework\Test
      */
     private function randomizeSuite($suite, $seed, $order = 0, $fix_depends = true)
     {

--- a/src/PHPUnitRandomizer/ResultPrinter.php
+++ b/src/PHPUnitRandomizer/ResultPrinter.php
@@ -2,7 +2,7 @@
 
 namespace PHPUnitRandomizer;
 
-class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
+class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
 {
     /**
      * Seed used to randomize the order of the tests.
@@ -18,7 +18,7 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
      * @param  boolean                     $verbose
      * @param  boolean                     $colors
      * @param  boolean                     $debug
-     * @throws PHPUnit_Framework_Exception
+     * @throws PHPUnit\Framework\Exception
      * @since  Method available since Release 3.0.0
      */
     public function __construct($out = null, $verbose = false, $colors = false, $debug = false, $seed = null)
@@ -29,10 +29,10 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
 
     /**
      * Just add to the output the seed used to randomize the test suite.
-     * 
-     * @param  PHPUnit_Framework_TestResult $result
+     *
+     * @param  PHPUnit\Framework\TestResult $result
      */
-    protected function printFooter(\PHPUnit_Framework_TestResult $result)
+    protected function printFooter(\PHPUnit\Framework\TestResult $result)
     {
         parent::printFooter($result);
 
@@ -40,4 +40,4 @@ class ResultPrinter extends \PHPUnit_TextUI_ResultPrinter
         $this->write("Randomized with seed: {$this->seed}");
         $this->writeNewLine();
     }
-} 
+}

--- a/src/PHPUnitRandomizer/TestRunner.php
+++ b/src/PHPUnitRandomizer/TestRunner.php
@@ -1,16 +1,16 @@
 <?php
 namespace PHPUnitRandomizer;
 
-class TestRunner extends \PHPUnit_TextUI_TestRunner
+class TestRunner extends \PHPUnit\TextUI\TestRunner
 {
     /**
      * Uses a random test suite to randomize the given test suite, and in case that no printer
      * has been selected, uses printer that shows the random seed used to randomize.
-     * 
-     * @param  PHPUnit_Framework_Test $suite     TestSuite to execute
+     *
+     * @param  PHPUnit\Framework\Test $suite     TestSuite to execute
      * @param  array                  $arguments Arguments to use
      */
-    public function doRun(\PHPUnit_Framework_Test $suite, array $arguments = array(), $exit = true)
+    public function doRun(\PHPUnit\Framework\Test $suite, array $arguments = array(), $exit = true)
     {
         $localArguments = $arguments;
 
@@ -40,7 +40,7 @@ class TestRunner extends \PHPUnit_TextUI_TestRunner
         );
 
         if (isset($arguments['printer']) &&
-            $arguments['printer'] instanceof \PHPUnit_Util_Printer) {
+            $arguments['printer'] instanceof \PHPUnit\Util\Printer) {
             $this->printer = $arguments['printer'];
         }
     }


### PR DESCRIPTION
Issue #20. 

I've made the minimum PHPUnit version 6.0, because for lower version users can simply use the previous releases of the randomizer.

My IDE also removed some trailing spaces.