### PR TITLE
[BUGFIX] Suite nesting may fatal

### DIFF
--- a/src/PHPUnitRandomizer/Randomizer.php
+++ b/src/PHPUnitRandomizer/Randomizer.php
@@ -39,10 +39,12 @@ class Randomizer
     {
         $order = 0;
         foreach ($suite->tests() as $test) {
-            if($this->testSuiteContainsOtherSuites($test)){
+            if ($test instanceof \PHPUnit\Framework\TestSuite && $this->testSuiteContainsOtherSuites($test)) {
                 $this->randomizeSuiteThatContainsOtherSuites($test, $seed);
             }
-            $this->randomizeSuite($test, $seed, $this->order);
+            if ($test instanceof \PHPUnit\Framework\TestSuite) {
+                $this->randomizeSuite($test, $seed, $this->order);
+            }
             $this->order++;
         }
         return $this->randomizeSuite($suite, $seed, $this->order, false);


### PR DESCRIPTION
Reordering may fatal since change 95ac72f: testSuiteContainsOtherSuites()
may also contain tests next to suites in its array, calling ->tests()
on non suite objects then fails.

Sanitize randomizeSuiteThatContainsOtherSuites() a bit to cope with that.