### PR TITLE
[TASK] phpunit 7 compatibility

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,13 @@
     ],
     "license": "MIT",
     "require": {
+        "php": "^7.1"
+    },
+    "conflict": {
+        "phpunit/phpunit": "<7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0"
+        "phpunit/phpunit": "^7.0"
     },
     "bin": ["bin/phpunit-randomizer"],
     "autoload": {

--- a/src/PHPUnitRandomizer/Command.php
+++ b/src/PHPUnitRandomizer/Command.php
@@ -8,11 +8,6 @@ class Command extends \PHPUnit\TextUI\Command
         $this->longOptions['order=']    = 'orderHandler';
     }
 
-    public static function main($exit = TRUE)
-    {
-        return parent::main($exit);
-    }
-
     /**
      * Only called when 'order' argument is used.
      *
@@ -51,12 +46,12 @@ class Command extends \PHPUnit\TextUI\Command
         return rand(0, 9999);
     }
 
-    protected function createRunner()
+    protected function createRunner(): \PHPUnit\TextUI\TestRunner
     {
         return new TestRunner($this->arguments['loader']);
     }
 
-    public function showHelp()
+    public function showHelp(): void
     {
         parent::showHelp();
 

--- a/src/PHPUnitRandomizer/ResultPrinter.php
+++ b/src/PHPUnitRandomizer/ResultPrinter.php
@@ -32,7 +32,7 @@ class ResultPrinter extends \PHPUnit\TextUI\ResultPrinter
      *
      * @param  PHPUnit\Framework\TestResult $result
      */
-    protected function printFooter(\PHPUnit\Framework\TestResult $result)
+    protected function printFooter(\PHPUnit\Framework\TestResult $result): void
     {
         parent::printFooter($result);
 

--- a/src/PHPUnitRandomizer/TestRunner.php
+++ b/src/PHPUnitRandomizer/TestRunner.php
@@ -10,7 +10,7 @@ class TestRunner extends \PHPUnit\TextUI\TestRunner
      * @param  PHPUnit\Framework\Test $suite     TestSuite to execute
      * @param  array                  $arguments Arguments to use
      */
-    public function doRun(\PHPUnit\Framework\Test $suite, array $arguments = array(), $exit = true)
+    public function doRun(\PHPUnit\Framework\Test $suite, array $arguments = array(), bool $exit = true): \PHPUnit\Framework\TestResult
     {
         $localArguments = $arguments;
 


### PR DESCRIPTION
This could be released as 4.0.0:
* Adapt method signatures to be compatible with phpunit 7
* Raise minimum php version to 7.1 due to :void return types
* Conflict with phpunit < 7.0 so composer does not upgrade
  to new version if phpunit 6 is still used